### PR TITLE
docs: READMEを各年齢の実際のゲーム構成に更新 (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,52 @@
 # Playful-Learning-Hub
 
-「わくわく学びランド」 (Waku Waku Learning Land) is a web application designed for children to learn and play. It offers a variety of games and activities tailored to different age groups, from toddlers to pre-teens.
+「わくわく学びランド」(Waku Waku Learning Land) is a web application designed for children to learn and play. It offers a variety of games and activities tailored to different age groups, from toddlers to pre-teens.
 
 ## Features
 
-The website is structured by age group, offering different educational games for each:
+The website is structured by age group, and each page bundles several games that can be switched between via an in-page navigation.
 
-*   **1-2 years old:** Sensory play, such as an animal sound quiz.
-*   **3-4 years old:** Games that nurture intellectual curiosity and social skills, like a classification game.
-*   **5-6 years old:** Activities to prepare for elementary school, such as a shopping game to learn about numbers and money.
-*   **7-8 years old (1st-2nd Grade):** Games to solidify foundational academic skills, like a math battle game.
-*   **9-10 years old (3rd-4th Grade):** Games that develop practical skills, such as a fraction pizza game.
-*   **11-12 years old (5th-6th Grade):** Activities that encourage inquiry-based learning, like a speed calculation game.
+*   **1-2 years old:** Sensory and early-counting play
+    *   Animal Sound Quiz (どうぶつのなきごえクイズ)
+    *   Counting Game (かずかぞえゲーム)
+    *   Rhythm Game (リズムゲーム)
+*   **3-4 years old:** Games that nurture intellectual curiosity and early literacy
+    *   Classification Game (なかまさがしゲーム)
+    *   Hiragana Learning (ひらがな学習)
+    *   Katakana Learning (カタカナ学習)
+    *   Counting Game (かずかぞえゲーム)
+    *   Tracing Play (なぞりあそび) — trace dotted lines and shapes
+*   **5-6 years old:** Activities to prepare for elementary school
+    *   Shopping Game (おかいものゲーム) — learn numbers through shopping
+    *   Hiragana & Katakana Learning (ひらがな・カタカナ学習)
+    *   Word Relay (ことばリレー) — shiritori word chain
+    *   Clock Play (とけいあそび)
+    *   Shape Puzzle (ずけいパズル)
+*   **7-8 years old (1st-2nd Grade):** Games to solidify foundational academic skills
+    *   Math Battle (算数バトル)
+    *   Multiplication Battle (九九バトル)
+    *   Kanji Puzzle (漢字パズル)
+    *   Word Relay (ことばリレー)
+*   **9-10 years old (3rd-4th Grade):** Games that develop practical skills
+    *   Fraction Pizza (分数ピザ)
+    *   Multiplication Battle (九九バトル)
+    *   Kanji Puzzle (漢字パズル)
+*   **11-12 years old (5th-6th Grade):** Activities that encourage inquiry-based learning
+    *   Speed Calculation (速さ計算)
+    *   Kanji Puzzle (漢字パズル)
+
+## Tech Stack
+
+*   Vanilla JavaScript (CommonJS modules), HTML, and CSS — no build step
+*   [Vitest](https://vitest.dev/) with [jsdom](https://github.com/jsdom/jsdom) for unit testing
+*   Shared infrastructure for sound (`audio-manager.js`), progress tracking (`progress-tracker.js`), badges (`badge-system.js`), and gamification (`gamification-system.js`)
+
+## Project Structure
+
+*   `index.html` — landing page linking to each age group
+*   `ages-*.html` — one page per age group, wiring together the games for that age
+*   `*-game.js`, `*-puzzle.js`, etc. — individual game modules (each with a matching `.test.js`)
+*   `style.css` — shared styles
 
 ## Development
 
@@ -29,6 +64,16 @@ To get started with development, you'll need to have Node.js and npm installed.
     ```bash
     npm test
     ```
+
+To preview the app, open `index.html` in a browser, or serve the directory with any static file server.
+
+## Testing
+
+Every game and shared module has a companion `*.test.js` file (25 in total), run with Vitest in a jsdom environment:
+
+```bash
+npm test
+```
 
 ## License
 


### PR DESCRIPTION
## 概要

PR #19 で追加された「なぞりあそび」を含め、各年齢ページが実際に提供するゲーム構成を README に反映しました。従来の README は各年齢「1ゲーム」のみの記載でしたが、実際は各ページが複数ゲームを切り替え式で束ねており、ドキュメントと実装に乖離が生じていました。

## 変更内容

- **Features**: 各年齢ページの実際のゲーム一覧（`ages-*.html` の `aria-label` から抽出した正式名称）に刷新。日本語名＋英語併記
  - 1-2歳: どうぶつのなきごえクイズ / かずかぞえ / リズム
  - 3-4歳: なかまさがし / ひらがな / カタカナ / かずかぞえ / **なぞりあそび（PR #19 追加分）**
  - 5-6歳: おかいもの / ひらがな・カタカナ / ことばリレー / とけい / ずけいパズル
  - 7-8歳: 算数バトル / 九九バトル / 漢字パズル / ことばリレー
  - 9-10歳: 分数ピザ / 九九バトル / 漢字パズル
  - 11-12歳: 速さ計算 / 漢字パズル
- **Tech Stack**: Vanilla JS / ビルド不要 / Vitest + jsdom / 共有基盤モジュール（`audio-manager`, `progress-tracker`, `badge-system`, `gamification-system`）
- **Project Structure**: `ages-*.html` とゲームモジュール群の役割を追記
- **Testing**: 全25テストファイルの実行方法（`npm test`）を明記

各ゲームの簡潔な説明は、モジュール名と各ページの `aria-label` 副題に基づき事実ベースで記載しています（推測による過剰な説明は避けています）。

## テスト計画

- [x] `npm test` → **336 tests passed (25 files)**
- [x] README の各ゲーム名を `ages-*.html` の `aria-label` と照合済み
- [ ] GitHub 上で README のマークダウンが正しくレンダリングされるか確認