### PR TITLE
feat(foreign-lang): 11-12歳に外国語単語ゲームを追加 (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The website is structured by age group, and each page bundles several games that
 *   **11-12 years old (5th-6th Grade):** Activities that encourage inquiry-based learning
     *   Speed Calculation (速さ計算)
     *   Kanji Puzzle (漢字パズル)
+    *   Foreign Language Words (えいごのことば) — vocabulary quiz with pronunciation
 *   **All ages (みんな):** Content playable across age groups
     *   Emotion Recognition (きもちあて) — match faces to feelings
 
@@ -72,7 +73,7 @@ To preview the app, open `index.html` in a browser, or serve the directory with 
 
 ## Testing
 
-Every game and shared module has a companion `*.test.js` file (26 in total), run with Vitest in a jsdom environment:
+Every game and shared module has a companion `*.test.js` file (27 in total), run with Vitest in a jsdom environment:
 
 ```bash
 npm test

--- a/ages-11-12.html
+++ b/ages-11-12.html
@@ -31,6 +31,13 @@
                     <span class="game-title">漢字パズル</span>
                     <span class="game-description">かんじをならおう</span>
                 </button>
+                <button id="foreign-lang-btn" class="game-nav-button"
+                        role="tab" aria-selected="false" aria-controls="foreign-lang-section"
+                        aria-label="えいごのことば - たんごをならおう">
+                    <span class="game-icon" aria-hidden="true">ABC</span>
+                    <span class="game-title">えいごのことば</span>
+                    <span class="game-description">たんごをならおう</span>
+                </button>
             </div>
         </div>
 
@@ -49,6 +56,12 @@
             <div id="kanji-puzzle-game-container"></div>
         </div>
 
+        <!-- えいごのことばセクション -->
+        <div id="foreign-lang-section" class="game-section"
+             role="tabpanel" aria-labelledby="foreign-lang-btn" aria-hidden="true">
+            <div id="foreign-lang-game"></div>
+        </div>
+
         <a href="index.html" class="back-link">トップにもどる</a>
     </main>
 
@@ -59,6 +72,7 @@
     <script src="speed-game.js"></script>
     <script src="kanji-data.js"></script>
     <script src="kanji-puzzle.js"></script>
+    <script src="foreign-lang-game.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             var kanjiPuzzleInstance = null;
@@ -93,6 +107,9 @@
             });
             document.getElementById('kanji-puzzle-btn').addEventListener('click', function() {
                 switchToGame('kanji-puzzle');
+            });
+            document.getElementById('foreign-lang-btn').addEventListener('click', function() {
+                switchToGame('foreign-lang');
             });
 
             switchToGame('speed');

--- a/foreign-lang-game.js
+++ b/foreign-lang-game.js
@@ -1,0 +1,195 @@
+/**
+ * えいごのことば（外国語の単語ゲーム）
+ * Foreign Language Word Game for ages 11-12
+ *
+ * 絵文字を見て英単語を当てるクイズ。正解時に Web Speech API で発音し、
+ * 単語帳（localStorage）に記録。単語帳の単語をタップすると再び発音する。
+ */
+
+function initForeignLangGame() {
+    const gameContainer = document.getElementById('foreign-lang-game');
+    if (!gameContainer) return;
+
+    const words = [
+        { ja: 'りんご', emoji: '🍎', en: 'apple' },
+        { ja: 'いぬ', emoji: '🐶', en: 'dog' },
+        { ja: 'くるま', emoji: '🚗', en: 'car' },
+        { ja: 'はな', emoji: '🌸', en: 'flower' },
+        { ja: 'ほし', emoji: '⭐', en: 'star' },
+        { ja: 'みず', emoji: '💧', en: 'water' },
+    ];
+
+    const STORAGE_KEY = 'foreign-lang-wordbook';
+    let currentWord = null;
+    let waitingForAnswer = false;
+
+    function loadWordbook() {
+        try {
+            const data = window.localStorage.getItem(STORAGE_KEY);
+            return data ? JSON.parse(data) : [];
+        } catch (e) {
+            return [];
+        }
+    }
+
+    function saveWordbook(book) {
+        try {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(book));
+        } catch (e) {
+            // 保存失敗は無視（プライベートモード等）
+        }
+    }
+
+    function addToWordbook(word) {
+        const book = loadWordbook();
+        if (!book.some(w => w.en === word.en)) {
+            book.push(word);
+            saveWordbook(book);
+        }
+    }
+
+    function speak(text) {
+        if (typeof window !== 'undefined' && window.speechSynthesis &&
+            typeof window.SpeechSynthesisUtterance === 'function') {
+            try {
+                const utter = new window.SpeechSynthesisUtterance(text);
+                utter.lang = 'en-US';
+                window.speechSynthesis.speak(utter);
+            } catch (e) {
+                // 音声失敗は無視
+            }
+        }
+    }
+
+    function shuffle(array) {
+        const arr = array.slice();
+        for (let i = arr.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            const tmp = arr[i];
+            arr[i] = arr[j];
+            arr[j] = tmp;
+        }
+        return arr;
+    }
+
+    function buildUI() {
+        gameContainer.textContent = '';
+
+        const header = document.createElement('div');
+        header.className = 'foreign-header';
+        const title = document.createElement('h2');
+        title.textContent = 'えいごのことば';
+        header.appendChild(title);
+        gameContainer.appendChild(header);
+
+        const questionEl = document.createElement('p');
+        questionEl.className = 'foreign-question';
+        questionEl.id = 'foreign-question';
+        questionEl.textContent = 'これをえいごでいうと？';
+        gameContainer.appendChild(questionEl);
+
+        const picture = document.createElement('div');
+        picture.className = 'foreign-picture';
+        picture.id = 'foreign-picture';
+        gameContainer.appendChild(picture);
+
+        const choices = document.createElement('div');
+        choices.className = 'foreign-choices';
+        choices.id = 'foreign-choices';
+        gameContainer.appendChild(choices);
+
+        const feedback = document.createElement('p');
+        feedback.className = 'foreign-feedback';
+        feedback.id = 'foreign-feedback';
+        gameContainer.appendChild(feedback);
+
+        const bookTitle = document.createElement('h3');
+        bookTitle.className = 'foreign-book-title';
+        bookTitle.textContent = '単語帳（おぼえたことば）';
+        gameContainer.appendChild(bookTitle);
+
+        const bookArea = document.createElement('div');
+        bookArea.className = 'foreign-wordbook';
+        bookArea.id = 'foreign-wordbook';
+        gameContainer.appendChild(bookArea);
+    }
+
+    function startRound() {
+        waitingForAnswer = true;
+
+        const feedback = document.getElementById('foreign-feedback');
+        feedback.textContent = '';
+        feedback.className = 'foreign-feedback';
+
+        const choices = document.getElementById('foreign-choices');
+        choices.textContent = '';
+
+        currentWord = words[Math.floor(Math.random() * words.length)];
+        document.getElementById('foreign-picture').textContent = currentWord.emoji;
+
+        const wrongs = shuffle(words.filter(w => w.en !== currentWord.en)).slice(0, 3);
+        const options = shuffle([currentWord, ...wrongs]);
+
+        options.forEach(w => {
+            const btn = document.createElement('button');
+            btn.className = 'foreign-choice-btn';
+            btn.textContent = w.en;
+            btn.dataset.en = w.en;
+            btn.addEventListener('click', () => checkAnswer(w.en, btn));
+            choices.appendChild(btn);
+        });
+    }
+
+    function checkAnswer(selected, btn) {
+        if (!waitingForAnswer) return;
+        waitingForAnswer = false;
+
+        const feedback = document.getElementById('foreign-feedback');
+        const isCorrect = selected === currentWord.en;
+
+        if (isCorrect) {
+            btn.classList.add('correct');
+            feedback.textContent = 'せいかい！ ' + currentWord.en + '（' + currentWord.ja + '）';
+            feedback.className = 'foreign-feedback correct';
+            speak(currentWord.en);
+            addToWordbook(currentWord);
+            renderWordbook();
+        } else {
+            btn.classList.add('incorrect');
+            feedback.textContent = 'ざんねん... こたえは ' + currentWord.en + ' だよ';
+            feedback.className = 'foreign-feedback incorrect';
+        }
+
+        setTimeout(startRound, 1800);
+    }
+
+    function renderWordbook() {
+        const area = document.getElementById('foreign-wordbook');
+        area.textContent = '';
+
+        const book = loadWordbook();
+        if (book.length === 0) {
+            area.textContent = 'まだありません。せいかいすると ここに でるよ！';
+            return;
+        }
+        book.forEach(w => {
+            const chip = document.createElement('button');
+            chip.className = 'foreign-word-chip';
+            chip.textContent = w.emoji + ' ' + w.en;
+            chip.addEventListener('click', () => speak(w.en));
+            area.appendChild(chip);
+        });
+    }
+
+    buildUI();
+    startRound();
+    renderWordbook();
+}
+
+if (typeof window !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', initForeignLangGame);
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { initForeignLangGame };
+}

--- a/foreign-lang-game.test.js
+++ b/foreign-lang-game.test.js
@@ -1,0 +1,136 @@
+/**
+ * えいごのことば（外国語の単語ゲーム）のテスト
+ * Tests for ForeignLangGame
+ */
+
+const { initForeignLangGame } = require('./foreign-lang-game.js');
+
+describe('initForeignLangGame', () => {
+    let container;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        container.id = 'foreign-lang-game';
+        document.body.appendChild(container);
+        const store = {};
+        window.localStorage = {
+            getItem: (k) => (Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null),
+            setItem: (k, v) => { store[k] = String(v); },
+            removeItem: (k) => { delete store[k]; },
+            clear: () => { Object.keys(store).forEach(k => delete store[k]); },
+        };
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+        delete window.localStorage;
+        vi.restoreAllMocks();
+        delete window.speechSynthesis;
+        delete window.SpeechSynthesisUtterance;
+    });
+
+    function fixedRandom() {
+        // 出題を words[0]=りんご/apple に固定（以降は0.5でシャッフルを決定論的に）
+        const calls = [0];
+        let i = 0;
+        return vi.spyOn(Math, 'random').mockImplementation(() => calls[i++] ?? 0.5);
+    }
+
+    test('コンテナが存在する場合、ゲームUIが作成される', () => {
+        initForeignLangGame();
+
+        expect(container.querySelector('.foreign-picture')).not.toBeNull();
+        expect(container.querySelector('.foreign-choices')).not.toBeNull();
+        expect(container.querySelector('.foreign-feedback')).not.toBeNull();
+        expect(container.querySelector('.foreign-wordbook')).not.toBeNull();
+    });
+
+    test('コンテナが存在しない場合はエラーにならない', () => {
+        expect(() => initForeignLangGame()).not.toThrow();
+    });
+
+    test('絵文字と選択肢4つが表示される', () => {
+        fixedRandom();
+        initForeignLangGame();
+
+        expect(container.querySelector('#foreign-picture').textContent).toBe('🍎');
+        expect(container.querySelectorAll('.foreign-choice-btn').length).toBe(4);
+    });
+
+    test('正解を選ぶと「せいかい」フィードバック', () => {
+        fixedRandom();
+        initForeignLangGame();
+
+        const correctBtn = Array.from(container.querySelectorAll('.foreign-choice-btn'))
+            .find(b => b.dataset.en === 'apple');
+        correctBtn.click();
+
+        const feedback = container.querySelector('#foreign-feedback');
+        expect(feedback.textContent).toContain('せいかい');
+        expect(feedback.textContent).toContain('apple');
+        expect(correctBtn.classList.contains('correct')).toBe(true);
+    });
+
+    test('不正解を選ぶとリトライフィードバック・答え表示', () => {
+        fixedRandom();
+        initForeignLangGame();
+
+        const wrongBtn = Array.from(container.querySelectorAll('.foreign-choice-btn'))
+            .find(b => b.dataset.en !== 'apple');
+        wrongBtn.click();
+
+        const feedback = container.querySelector('#foreign-feedback');
+        expect(feedback.textContent).toContain('ざんねん');
+        expect(wrongBtn.classList.contains('incorrect')).toBe(true);
+    });
+
+    test('単語帳は初期状態で「まだありません」', () => {
+        initForeignLangGame();
+
+        expect(container.querySelector('#foreign-wordbook').textContent).toContain('まだありません');
+    });
+
+    test('正解すると単語帳にchipが追加される', () => {
+        fixedRandom();
+        initForeignLangGame();
+
+        const correctBtn = Array.from(container.querySelectorAll('.foreign-choice-btn'))
+            .find(b => b.dataset.en === 'apple');
+        correctBtn.click();
+
+        const chips = container.querySelectorAll('.foreign-word-chip');
+        expect(chips.length).toBe(1);
+        expect(chips[0].textContent).toContain('apple');
+    });
+
+    test('正解時にspeechSynthesis.speakが呼ばれる', () => {
+        const speak = vi.fn();
+        window.speechSynthesis = { speak };
+        window.SpeechSynthesisUtterance = function (text) { this.text = text; };
+        fixedRandom();
+
+        initForeignLangGame();
+
+        const correctBtn = Array.from(container.querySelectorAll('.foreign-choice-btn'))
+            .find(b => b.dataset.en === 'apple');
+        correctBtn.click();
+
+        expect(speak).toHaveBeenCalledTimes(1);
+    });
+
+    test('正解後、次の問題へ進む（フィードバックリセット）', () => {
+        fixedRandom();
+        vi.useFakeTimers();
+        initForeignLangGame();
+
+        const correctBtn = Array.from(container.querySelectorAll('.foreign-choice-btn'))
+            .find(b => b.dataset.en === 'apple');
+        correctBtn.click();
+
+        vi.advanceTimersByTime(2000);
+
+        expect(container.querySelector('#foreign-feedback').textContent).toBe('');
+
+        vi.useRealTimers();
+    });
+});

--- a/style.css
+++ b/style.css
@@ -3055,3 +3055,103 @@ footer {
 .emotion-feedback.incorrect {
     color: #c62828;
 }
+
+/* ========================================
+   えいごのことば（外国語の単語ゲーム）
+   ======================================== */
+.foreign-header h2 {
+    margin: 0;
+}
+
+.foreign-question {
+    text-align: center;
+    font-size: 1.2rem;
+    color: #555;
+    margin: 12px 0;
+}
+
+.foreign-picture {
+    font-size: 7rem;
+    text-align: center;
+    margin: 20px 0;
+}
+
+.foreign-choices {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    flex-wrap: wrap;
+    padding: 16px;
+}
+
+.foreign-choice-btn {
+    font-size: 1.4rem;
+    font-weight: bold;
+    min-width: 110px;
+    padding: 14px 20px;
+    border: 3px solid #7986cb;
+    border-radius: 16px;
+    background: #fff;
+    color: #1a237e;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.foreign-choice-btn:hover {
+    background: #e8eaf6;
+    transform: scale(1.05);
+}
+
+.foreign-choice-btn.correct {
+    background: #c8e6c9;
+    border-color: #2e7d32;
+}
+
+.foreign-choice-btn.incorrect {
+    background: #ffcdd2;
+    border-color: #c62828;
+}
+
+.foreign-feedback {
+    text-align: center;
+    font-size: 1.2rem;
+    font-weight: bold;
+    margin: 16px 0;
+    min-height: 2em;
+}
+
+.foreign-feedback.correct {
+    color: #2e7d32;
+}
+
+.foreign-feedback.incorrect {
+    color: #c62828;
+}
+
+.foreign-book-title {
+    margin-top: 24px;
+    color: #3949ab;
+}
+
+.foreign-wordbook {
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+    flex-wrap: wrap;
+    padding: 12px;
+    min-height: 2em;
+    color: #777;
+}
+
+.foreign-word-chip {
+    font-size: 1rem;
+    padding: 8px 14px;
+    border: 2px solid #7986cb;
+    border-radius: 999px;
+    background: #e8eaf6;
+    cursor: pointer;
+}
+
+.foreign-word-chip:hover {
+    background: #c5cae9;
+}


### PR DESCRIPTION
外国語単語ゲーム「えいごのことば」を11-12歳ページに追加。

- foreign-lang-game.js / foreign-lang-game.test.js（新規、9テスト）
- ages-11-12.html（ナビ/セクション/script/リスナー）
- style.css（foreign-*）、README.md

全テスト通過、foreign-lang-game 9テスト。絵文字→英単語クイズ、Web Speech APIで発音、localStorageで単語帳。

Closes #13