### PR TITLE
feat(seasonal): 全年齢向けに季節イベント機能を追加 (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The website is structured by age group, and each page bundles several games that
     *   Kanji Puzzle (漢字パズル)
 *   **All ages (みんな):** Content playable across age groups
     *   Emotion Recognition (きもちあて) — match faces to feelings
+    *   Seasonal Events (きせつのイベント) — time-limited holiday games
 
 ## Tech Stack
 
@@ -72,7 +73,7 @@ To preview the app, open `index.html` in a browser, or serve the directory with 
 
 ## Testing
 
-Every game and shared module has a companion `*.test.js` file (26 in total), run with Vitest in a jsdom environment:
+Every game and shared module has a companion `*.test.js` file (27 in total), run with Vitest in a jsdom environment:
 
 ```bash
 npm test

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
         <p>遊びながら楽しく学べる、子どもたちのためのウェブサイト！</p>
     </header>
 
+    <div id="seasonal-banner" role="region" aria-label="季節のイベント"></div>
+
     <main>
         <h2>年齢を選んでね</h2>
         <nav class="age-groups">
@@ -49,5 +51,7 @@
     <footer>
         <p>&copy; 2024 わくわく学びランド</p>
     </footer>
+
+    <script src="seasonal-event.js"></script>
 </body>
 </html>

--- a/seasonal-event.js
+++ b/seasonal-event.js
@@ -1,0 +1,120 @@
+/**
+ * きせつのイベント（季節のイベント機能）
+ * Seasonal Event feature (all ages)
+ *
+ * 期間中（ハロウィン/お正月など）だけ index.html のバナー(#seasonal-banner)に
+ * イベントを表示し、「あそぶ」で季節のミニクイズを開く。
+ * 日付は引数で注入可能（テスト容易化）。本番は new Date()。
+ */
+
+function getSeasonalEvent(date) {
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+
+    if ((month === 10 && day >= 15) || (month === 11 && day <= 5)) {
+        return { key: 'halloween', name: 'ハロウィン', emoji: '🎃' };
+    }
+    if ((month === 12 && day >= 20) || (month === 1 && day <= 5)) {
+        return { key: 'newyear', name: 'おしょうがつ', emoji: '🎎' };
+    }
+    return null;
+}
+
+const seasonalQuizzes = {
+    halloween: {
+        question: 'ハロウィんで おばけに なるために かぶる ものは？',
+        choices: ['おばけのかめん', 'ぼうし', 'くつした'],
+        answer: 'おばけのかめん',
+    },
+    newyear: {
+        question: 'おしょうがつに あそぶ まわす おもちゃは？',
+        choices: ['こま', 'ボール', 'たまご'],
+        answer: 'こま',
+    },
+};
+
+function initSeasonalEvent(now) {
+    const banner = document.getElementById('seasonal-banner');
+    if (!banner) return;
+
+    const date = now || new Date();
+    const event = getSeasonalEvent(date);
+
+    banner.textContent = '';
+    if (!event) {
+        return;
+    }
+
+    const card = document.createElement('div');
+    card.className = 'seasonal-card seasonal-' + event.key;
+
+    const icon = document.createElement('span');
+    icon.className = 'seasonal-icon';
+    icon.textContent = event.emoji;
+
+    const label = document.createElement('span');
+    label.className = 'seasonal-label';
+    label.textContent = event.name + 'あそび があるよ！';
+
+    const playBtn = document.createElement('button');
+    playBtn.className = 'seasonal-play-btn';
+    playBtn.textContent = 'あそぶ';
+    playBtn.addEventListener('click', () => showQuiz(event.key, banner));
+
+    card.appendChild(icon);
+    card.appendChild(label);
+    card.appendChild(playBtn);
+    banner.appendChild(card);
+}
+
+function showQuiz(key, container) {
+    const quiz = seasonalQuizzes[key];
+    if (!quiz) return;
+
+    const existing = container.querySelector('.seasonal-quiz');
+    if (existing) {
+        existing.remove();
+    }
+
+    const quizEl = document.createElement('div');
+    quizEl.className = 'seasonal-quiz';
+
+    const q = document.createElement('p');
+    q.className = 'seasonal-question';
+    q.textContent = quiz.question;
+    quizEl.appendChild(q);
+
+    const choices = document.createElement('div');
+    choices.className = 'seasonal-choices';
+    quiz.choices.forEach(c => {
+        const btn = document.createElement('button');
+        btn.className = 'seasonal-choice-btn';
+        btn.textContent = c;
+        btn.addEventListener('click', () => {
+            const feedback = quizEl.querySelector('.seasonal-feedback');
+            if (c === quiz.answer) {
+                feedback.textContent = 'せいかい！ 🎉';
+                feedback.className = 'seasonal-feedback correct';
+            } else {
+                feedback.textContent = 'ざんねん... もういっかい！';
+                feedback.className = 'seasonal-feedback incorrect';
+            }
+        });
+        choices.appendChild(btn);
+    });
+    quizEl.appendChild(choices);
+
+    const feedback = document.createElement('p');
+    feedback.className = 'seasonal-feedback';
+    quizEl.appendChild(feedback);
+
+    container.appendChild(quizEl);
+}
+
+if (typeof window !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', function () { initSeasonalEvent(); });
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { initSeasonalEvent, getSeasonalEvent };
+}

--- a/seasonal-event.test.js
+++ b/seasonal-event.test.js
@@ -1,0 +1,98 @@
+/**
+ * きせつのイベント（季節のイベント機能）のテスト
+ * Tests for SeasonalEvent
+ */
+
+const { initSeasonalEvent, getSeasonalEvent } = require('./seasonal-event.js');
+
+describe('getSeasonalEvent', () => {
+    test('10月20日はハロウィン', () => {
+        expect(getSeasonalEvent(new Date(2026, 9, 20)).key).toBe('halloween');
+    });
+
+    test('11月1日はハロウィン', () => {
+        expect(getSeasonalEvent(new Date(2026, 10, 1)).key).toBe('halloween');
+    });
+
+    test('1月3日はお正月', () => {
+        expect(getSeasonalEvent(new Date(2026, 0, 3)).key).toBe('newyear');
+    });
+
+    test('12月25日はお正月期間', () => {
+        expect(getSeasonalEvent(new Date(2026, 11, 25)).key).toBe('newyear');
+    });
+
+    test('8月15日は期間外でnull', () => {
+        expect(getSeasonalEvent(new Date(2026, 7, 15))).toBeNull();
+    });
+});
+
+describe('initSeasonalEvent', () => {
+    let container;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        container.id = 'seasonal-banner';
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    test('バナー不在でもエラーにならない', () => {
+        expect(() => initSeasonalEvent(new Date(2026, 9, 20))).not.toThrow();
+    });
+
+    test('期間内はバナー表示', () => {
+        initSeasonalEvent(new Date(2026, 9, 20)); // 10/20
+
+        expect(container.querySelector('.seasonal-card')).not.toBeNull();
+        expect(container.textContent).toContain('ハロウィン');
+        expect(container.querySelector('.seasonal-play-btn')).not.toBeNull();
+    });
+
+    test('期間外はバナーが空', () => {
+        initSeasonalEvent(new Date(2026, 7, 15)); // 8/15
+
+        expect(container.querySelector('.seasonal-card')).toBeNull();
+        expect(container.textContent).toBe('');
+    });
+
+    test('あそぶボタンでクイズ表示', () => {
+        initSeasonalEvent(new Date(2026, 9, 20));
+        container.querySelector('.seasonal-play-btn').click();
+
+        expect(container.querySelector('.seasonal-quiz')).not.toBeNull();
+        expect(container.querySelectorAll('.seasonal-choice-btn').length).toBe(3);
+    });
+
+    test('クイズ正解で「せいかい」', () => {
+        initSeasonalEvent(new Date(2026, 9, 20));
+        container.querySelector('.seasonal-play-btn').click();
+
+        const correctBtn = Array.from(container.querySelectorAll('.seasonal-choice-btn'))
+            .find(b => b.textContent === 'おばけのかめん');
+        correctBtn.click();
+
+        expect(container.querySelector('.seasonal-feedback').textContent).toContain('せいかい');
+    });
+
+    test('クイズ不正解で「ざんねん」', () => {
+        initSeasonalEvent(new Date(2026, 9, 20));
+        container.querySelector('.seasonal-play-btn').click();
+
+        const wrongBtn = Array.from(container.querySelectorAll('.seasonal-choice-btn'))
+            .find(b => b.textContent === 'ぼうし');
+        wrongBtn.click();
+
+        expect(container.querySelector('.seasonal-feedback').textContent).toContain('ざんねん');
+    });
+
+    test('お正月期間はお正月クイズ', () => {
+        initSeasonalEvent(new Date(2026, 0, 3)); // 1/3
+        container.querySelector('.seasonal-play-btn').click();
+
+        expect(container.querySelector('.seasonal-question').textContent).toContain('おもちゃ');
+    });
+});

--- a/style.css
+++ b/style.css
@@ -3055,3 +3055,95 @@ footer {
 .emotion-feedback.incorrect {
     color: #c62828;
 }
+
+/* ========================================
+   きせつのイベント（季節のイベント機能）
+   ======================================== */
+.seasonal-card {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    max-width: 600px;
+    margin: 16px auto;
+    padding: 16px;
+    border-radius: 12px;
+}
+
+.seasonal-halloween {
+    background: #ffe0b2;
+    border: 3px solid #fb8c00;
+}
+
+.seasonal-newyear {
+    background: #ffcdd2;
+    border: 3px solid #e53935;
+}
+
+.seasonal-icon {
+    font-size: 2.5rem;
+}
+
+.seasonal-label {
+    font-weight: bold;
+    color: #4e342e;
+}
+
+.seasonal-play-btn {
+    font-size: 1rem;
+    padding: 8px 20px;
+    border: none;
+    border-radius: 999px;
+    background: #5d4037;
+    color: #fff;
+    cursor: pointer;
+}
+
+.seasonal-quiz {
+    max-width: 500px;
+    margin: 12px auto;
+    padding: 16px;
+    background: #fff;
+    border-radius: 12px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+
+.seasonal-question {
+    font-size: 1.2rem;
+    font-weight: bold;
+    margin: 8px 0;
+}
+
+.seasonal-choices {
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin: 12px 0;
+}
+
+.seasonal-choice-btn {
+    font-size: 1rem;
+    padding: 10px 18px;
+    border: 2px solid #fb8c00;
+    border-radius: 12px;
+    background: #fff;
+    cursor: pointer;
+}
+
+.seasonal-choice-btn:hover {
+    background: #fff3e0;
+}
+
+.seasonal-feedback {
+    font-weight: bold;
+    min-height: 1.5em;
+}
+
+.seasonal-feedback.correct {
+    color: #2e7d32;
+}
+
+.seasonal-feedback.incorrect {
+    color: #c62828;
+}


### PR DESCRIPTION
季節イベント機能「きせつのイベント」をindex.htmlに追加。

- seasonal-event.js / seasonal-event.test.js（新規、12テスト）
- index.html（#seasonal-banner容器 + スクリプト読み込み）
- style.css（seasonal-*）、README.md

全テスト通過、seasonal-event 12テスト。期間判定（ハロウィン10/15-11/5、お正月12/20-1/5）でバナー表示、クリックで季節クイズ。

Closes #15