### PR TITLE
fix(instrument): コンテナ不在テストのafterEachを安全化

### DIFF
--- a/instrument-sim.test.js
+++ b/instrument-sim.test.js
@@ -15,7 +15,9 @@ describe('initInstrumentSim', () => {
     });
 
     afterEach(() => {
-        document.body.removeChild(container);
+        if (container.parentNode) {
+            document.body.removeChild(container);
+        }
         vi.restoreAllMocks();
         delete window.AudioContext;
         delete window.webkitAudioContext;


### PR DESCRIPTION
#8 でマージされた instrument-sim.test.js の afterEach が container.parentNode チェックなしで removeChild しており、コンテナ不在テストで二重削除エラーになっていたのを修正。

afterEach を parentNode チェック付きに安全化。全テスト通過。