### PR TITLE
fix(story): showNodeの2重定義を解消

### DIFF
--- a/story-creator.js
+++ b/story-creator.js
@@ -94,15 +94,6 @@ function initStoryCreator() {
         showNode('start');
     }
 
-    function showNode(id, resetPath = false) {
-        const node = story[id];
-        if (!node) return;
-        
-        if (resetPath) {
-            path = [];
-        }
-        path.push(node.text);
-
     function showNode(id) {
         const node = story[id];
         if (!node) return;


### PR DESCRIPTION
#11 でマージされた story-creator.js の showNode が2重定義（resetPath版の断片と原本が混在）で SyntaxError になっていたのを修正。原本を残して断片を削除。