### PR TITLE
feat(user-content): 全年齢向けにユーザー作成クイズ機能を追加 (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The website is structured by age group, and each page bundles several games that
     *   Foreign Language Words (えいごのことば) — vocabulary quiz with pronunciation
 *   **All ages (みんな):** Content playable across age groups
     *   Emotion Recognition (きもちあて) — match faces to feelings
+    *   User-Created Quizzes (クイズをつくろう) — make and play your own quizzes
 
 ## Tech Stack
 
@@ -76,7 +77,7 @@ To preview the app, open `index.html` in a browser, or serve the directory with 
 
 ## Testing
 
-Every game and shared module has a companion `*.test.js` file (31 in total), run with Vitest in a jsdom environment:
+Every game and shared module has a companion `*.test.js` file (32 in total), run with Vitest in a jsdom environment:
 
 
 ```bash

--- a/all-ages.html
+++ b/all-ages.html
@@ -24,6 +24,13 @@
                     <span class="game-title">きもちあて</span>
                     <span class="game-description">ひょうじょうをあてよう</span>
                 </button>
+                <button id="user-content-btn" class="game-nav-button"
+                        role="tab" aria-selected="false" aria-controls="user-content-section"
+                        aria-label="クイズをつくろう - じぶんだけのクイズをつくろう">
+                    <span class="game-icon" aria-hidden="true">✏️</span>
+                    <span class="game-title">クイズづくり</span>
+                    <span class="game-description">じぶんでつくろう</span>
+                </button>
             </div>
         </div>
 
@@ -31,6 +38,12 @@
         <div id="emotion-game-section" class="game-section active"
              role="tabpanel" aria-labelledby="emotion-game-btn">
             <div id="emotion-game"></div>
+        </div>
+
+        <!-- ユーザー作成コンテンツセクション -->
+        <div id="user-content-section" class="game-section"
+             role="tabpanel" aria-labelledby="user-content-btn" aria-hidden="true">
+            <div id="user-content"></div>
         </div>
 
         <a href="index.html" class="back-link">トップにもどる</a>
@@ -42,6 +55,7 @@
 
     <script src="audio-manager.js"></script>
     <script src="emotion-game.js"></script>
+    <script src="user-content.js"></script>
     <script>
         // ゲームナビゲーション機能（将来の全年齢向けゲーム追加も gameType で拡張可能）
         function switchToGame(gameType) {
@@ -71,6 +85,12 @@
             if (emotionBtn) {
                 emotionBtn.addEventListener('click', function() {
                     switchToGame('emotion');
+                });
+            }
+            const userContentBtn = document.getElementById('user-content-btn');
+            if (userContentBtn) {
+                userContentBtn.addEventListener('click', function() {
+                    switchToGame('user-content');
                 });
             }
             switchToGame('emotion');

--- a/style.css
+++ b/style.css
@@ -2969,6 +2969,135 @@ footer {
 }
 
 /* ========================================
+   クイズをつくろう（ユーザー作成コンテンツ）
+   ======================================== */
+.user-content-header h2 {
+    margin: 0;
+}
+
+.user-content-body {
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.uc-button {
+    font-size: 1rem;
+    padding: 8px 16px;
+    margin: 4px;
+    border: 2px solid #455a64;
+    border-radius: 999px;
+    background: #fff;
+    color: #263238;
+    cursor: pointer;
+}
+
+.uc-button.uc-primary {
+    background: #26a69a;
+    color: #fff;
+    border-color: #26a69a;
+}
+
+.uc-button.uc-warn {
+    background: #fff3e0;
+    color: #e65100;
+    border-color: #fb8c00;
+}
+
+.uc-button.uc-danger {
+    background: #ffebee;
+    color: #c62828;
+    border-color: #e53935;
+}
+
+.uc-list {
+    margin-top: 16px;
+}
+
+.uc-card {
+    background: #f5f5f5;
+    border-radius: 12px;
+    padding: 12px;
+    margin: 8px 0;
+}
+
+.uc-card.reported {
+    opacity: 0.5;
+    border: 2px dashed #e53935;
+}
+
+.uc-card-title {
+    font-weight: bold;
+    margin: 0 0 8px;
+}
+
+.uc-field {
+    display: block;
+    margin: 8px 0;
+    text-align: left;
+}
+
+.uc-input {
+    display: block;
+    width: 80%;
+    padding: 6px;
+    margin: 4px auto;
+    font-size: 1rem;
+}
+
+.uc-message {
+    color: #c62828;
+    font-weight: bold;
+    min-height: 1.5em;
+}
+
+.uc-play-question {
+    font-size: 1.3rem;
+    font-weight: bold;
+    margin: 16px 0;
+}
+
+.uc-play-choices {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: center;
+}
+
+.uc-choice-btn {
+    font-size: 1.1rem;
+    padding: 10px 24px;
+    width: 60%;
+    border: 2px solid #26a69a;
+    border-radius: 12px;
+    background: #fff;
+    cursor: pointer;
+}
+
+.uc-choice-btn.correct {
+    background: #c8e6c9;
+    border-color: #2e7d32;
+}
+
+.uc-choice-btn.incorrect {
+    background: #ffcdd2;
+    border-color: #c62828;
+}
+
+.uc-feedback {
+    font-weight: bold;
+    margin-top: 12px;
+    min-height: 1.5em;
+}
+
+.uc-feedback.correct {
+    color: #2e7d32;
+}
+
+.uc-feedback.incorrect {
+    color: #c62828;
+}
+
+/* ========================================
    がっきたいきごう（楽器シミュレーション）
    ======================================== */
 .instrument-header h2 {

--- a/user-content.js
+++ b/user-content.js
@@ -1,0 +1,290 @@
+/**
+ * クイズをつくろう（ユーザー作成コンテンツ）
+ * User-Generated Content (all ages)
+ *
+ * 子どもが自分でクイズを作って遊べる（localStorage 版：同ブラウザ内で作成・保存・プレイ）。
+ * NGワードの簡易フィルタと、不適切内容の報告マーク機能付き。
+ * 静的サイト（バックエンドなし）のため「他ユーザーとの公開共有」は不可。
+ */
+
+function initUserContent() {
+    const container = document.getElementById('user-content');
+    if (!container) return;
+
+    var STORAGE_KEY = 'user-content-quizzes';
+    var NG_WORDS = ['ばか', 'あほ', 'しね', 'くそ', 'まぬけ'];
+
+    var playTarget = null;
+
+    function loadQuizzes() {
+        try {
+            var data = window.localStorage.getItem(STORAGE_KEY);
+            return data ? JSON.parse(data) : [];
+        } catch (e) {
+            return [];
+        }
+    }
+
+    function saveQuizzes(list) {
+        try {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+        } catch (e) {
+            // 保存失敗は無視
+        }
+    }
+
+    function hasNgWord(text) {
+        var s = String(text);
+        return NG_WORDS.some(function (w) { return s.indexOf(w) !== -1; });
+    }
+
+    function buildUI() {
+        container.textContent = '';
+
+        var header = document.createElement('div');
+        header.className = 'user-content-header';
+        var title = document.createElement('h2');
+        title.textContent = 'クイズをつくろう';
+        header.appendChild(title);
+        container.appendChild(header);
+
+        var body = document.createElement('div');
+        body.className = 'user-content-body';
+        body.id = 'user-content-body';
+        container.appendChild(body);
+
+        renderMenu();
+    }
+
+    function renderMenu() {
+        var body = document.getElementById('user-content-body');
+        body.textContent = '';
+
+        var createBtn = document.createElement('button');
+        createBtn.className = 'uc-button uc-primary';
+        createBtn.id = 'uc-create-btn';
+        createBtn.textContent = '新しいクイズをつくる';
+        createBtn.addEventListener('click', renderCreateForm);
+        body.appendChild(createBtn);
+
+        var listTitle = document.createElement('h3');
+        listTitle.textContent = 'つくったクイズ';
+        body.appendChild(listTitle);
+
+        var list = loadQuizzes();
+        var listEl = document.createElement('div');
+        listEl.className = 'uc-list';
+        listEl.id = 'uc-list';
+        if (list.length === 0) {
+            listEl.textContent = 'まだありません。つくってみよう！';
+        } else {
+            list.forEach(function (q) { listEl.appendChild(makeQuizCard(q)); });
+        }
+        body.appendChild(listEl);
+    }
+
+    function makeQuizCard(q) {
+        var card = document.createElement('div');
+        card.className = 'uc-card' + (q.reported ? ' reported' : '');
+
+        var title = document.createElement('p');
+        title.className = 'uc-card-title';
+        title.textContent = q.question;
+        card.appendChild(title);
+
+        var playBtn = document.createElement('button');
+        playBtn.className = 'uc-button';
+        playBtn.textContent = 'あそぶ';
+        playBtn.addEventListener('click', function () { playTarget = q; renderPlay(); });
+        card.appendChild(playBtn);
+
+        var reportBtn = document.createElement('button');
+        reportBtn.className = 'uc-button uc-warn';
+        reportBtn.textContent = 'ほうこく';
+        reportBtn.addEventListener('click', function () { reportQuiz(q.id); });
+        card.appendChild(reportBtn);
+
+        var delBtn = document.createElement('button');
+        delBtn.className = 'uc-button uc-danger';
+        delBtn.textContent = 'けす';
+        delBtn.addEventListener('click', function () { deleteQuiz(q.id); });
+        card.appendChild(delBtn);
+
+        return card;
+    }
+
+    function renderCreateForm() {
+        var body = document.getElementById('user-content-body');
+        body.textContent = '';
+
+        var backBtn = document.createElement('button');
+        backBtn.className = 'uc-button';
+        backBtn.textContent = 'もどる';
+        backBtn.addEventListener('click', renderMenu);
+        body.appendChild(backBtn);
+
+        var qLabel = document.createElement('label');
+        qLabel.className = 'uc-field';
+        qLabel.textContent = 'もんだい：';
+        var qInput = document.createElement('input');
+        qInput.type = 'text';
+        qInput.id = 'uc-question';
+        qInput.className = 'uc-input';
+        qLabel.appendChild(qInput);
+        body.appendChild(qLabel);
+
+        for (var i = 0; i < 4; i++) {
+            var field = document.createElement('div');
+            field.className = 'uc-field';
+
+            var label = document.createElement('span');
+            label.textContent = 'せんたし' + (i + 1) + '：';
+            field.appendChild(label);
+
+            var input = document.createElement('input');
+            input.type = 'text';
+            input.className = 'uc-input uc-choice';
+            input.dataset.index = String(i);
+            field.appendChild(input);
+
+            var radio = document.createElement('input');
+            radio.type = 'radio';
+            radio.name = 'uc-answer';
+            radio.value = String(i);
+            radio.className = 'uc-answer-radio';
+            radio.setAttribute('aria-label', 'せんたし' + (i + 1) + 'をせいかいにする');
+            field.appendChild(radio);
+
+            body.appendChild(field);
+        }
+
+        var msg = document.createElement('p');
+        msg.className = 'uc-message';
+        msg.id = 'uc-message';
+        body.appendChild(msg);
+
+        var saveBtn = document.createElement('button');
+        saveBtn.className = 'uc-button uc-primary';
+        saveBtn.id = 'uc-save-btn';
+        saveBtn.textContent = 'ほぞん';
+        saveBtn.addEventListener('click', saveNewQuiz);
+        body.appendChild(saveBtn);
+    }
+
+    function saveNewQuiz() {
+        var qInput = document.getElementById('uc-question');
+        var msg = document.getElementById('uc-message');
+        var choices = Array.prototype.slice.call(document.querySelectorAll('.uc-choice'))
+            .map(function (i) { return i.value.trim(); });
+        var radio = document.querySelector('.uc-answer-radio:checked');
+
+        var question = (qInput.value || '').trim();
+        if (!question) {
+            msg.textContent = 'もんだいを いれてね';
+            return;
+        }
+        if (choices.some(function (c) { return !c; })) {
+            msg.textContent = 'せんたしを 4つ すべて いれてね';
+            return;
+        }
+        if (!radio) {
+            msg.textContent = 'せいかいの せんたしを えらんでね';
+            return;
+        }
+        if (hasNgWord(question) || choices.some(hasNgWord)) {
+            msg.textContent = 'もうしわけない、つかえない ことばが あります';
+            return;
+        }
+
+        var answerIndex = parseInt(radio.value, 10);
+        var list = loadQuizzes();
+        list.push({
+            id: 'q' + list.length + '-' + question.length,
+            question: question,
+            choices: choices,
+            answerIndex: answerIndex,
+            reported: false
+        });
+        saveQuizzes(list);
+        renderMenu();
+    }
+
+    function renderPlay() {
+        var body = document.getElementById('user-content-body');
+        body.textContent = '';
+        var q = playTarget;
+        if (!q) {
+            renderMenu();
+            return;
+        }
+
+        var backBtn = document.createElement('button');
+        backBtn.className = 'uc-button';
+        backBtn.textContent = 'もどる';
+        backBtn.addEventListener('click', renderMenu);
+        body.appendChild(backBtn);
+
+        var qEl = document.createElement('p');
+        qEl.className = 'uc-play-question';
+        qEl.id = 'uc-play-question';
+        qEl.textContent = q.question;
+        body.appendChild(qEl);
+
+        var choicesEl = document.createElement('div');
+        choicesEl.className = 'uc-play-choices';
+        choicesEl.id = 'uc-play-choices';
+        q.choices.forEach(function (c, i) {
+            var btn = document.createElement('button');
+            btn.className = 'uc-choice-btn';
+            btn.textContent = c;
+            btn.dataset.index = String(i);
+            btn.addEventListener('click', function () { answerPlay(i, btn); });
+            choicesEl.appendChild(btn);
+        });
+        body.appendChild(choicesEl);
+
+        var feedback = document.createElement('p');
+        feedback.className = 'uc-feedback';
+        feedback.id = 'uc-feedback';
+        body.appendChild(feedback);
+    }
+
+    function answerPlay(selected, btn) {
+        var feedback = document.getElementById('uc-feedback');
+        if (selected === playTarget.answerIndex) {
+            btn.classList.add('correct');
+            feedback.textContent = 'せいかい！ 🎉';
+            feedback.className = 'uc-feedback correct';
+        } else {
+            btn.classList.add('incorrect');
+            feedback.textContent = 'ざんねん... せいかいは「' + playTarget.choices[playTarget.answerIndex] + '」だよ';
+            feedback.className = 'uc-feedback incorrect';
+        }
+    }
+
+    function reportQuiz(id) {
+        var list = loadQuizzes();
+        var q = list.find(function (x) { return x.id === id; });
+        if (q) {
+            q.reported = true;
+            saveQuizzes(list);
+            renderMenu();
+        }
+    }
+
+    function deleteQuiz(id) {
+        var list = loadQuizzes().filter(function (x) { return x.id !== id; });
+        saveQuizzes(list);
+        renderMenu();
+    }
+
+    buildUI();
+}
+
+if (typeof window !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', initUserContent);
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { initUserContent };
+}

--- a/user-content.test.js
+++ b/user-content.test.js
@@ -1,0 +1,146 @@
+/**
+ * クイズをつくろう（ユーザー作成コンテンツ）のテスト
+ * Tests for UserContent
+ */
+
+const { initUserContent } = require('./user-content.js');
+
+describe('initUserContent', () => {
+    let container;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        container.id = 'user-content';
+        document.body.appendChild(container);
+        const store = {};
+        window.localStorage = {
+            getItem: (k) => (Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null),
+            setItem: (k, v) => { store[k] = String(v); },
+            removeItem: (k) => { delete store[k]; },
+            clear: () => { Object.keys(store).forEach(k => delete store[k]); },
+        };
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+        delete window.localStorage;
+    });
+
+    function fillCreateForm(question, choiceTexts, answerIndex) {
+        document.getElementById('uc-question').value = question;
+        const choices = document.querySelectorAll('.uc-choice');
+        choiceTexts.forEach((t, i) => { choices[i].value = t; });
+        if (typeof answerIndex === 'number') {
+            document.querySelectorAll('.uc-answer-radio')[answerIndex].checked = true;
+        }
+    }
+
+    test('コンテナが存在する場合、メニューUIが作成される', () => {
+        initUserContent();
+
+        expect(container.querySelector('#uc-create-btn')).not.toBeNull();
+        expect(container.querySelector('#uc-list')).not.toBeNull();
+    });
+
+    test('コンテナが存在しない場合はエラーにならない', () => {
+        expect(() => initUserContent()).not.toThrow();
+    });
+
+    test('初期状態はリストが空のメッセージ', () => {
+        initUserContent();
+
+        expect(container.querySelector('#uc-list').textContent).toContain('まだありません');
+    });
+
+    test('つくるボタンで作成フォームが表示される', () => {
+        initUserContent();
+        container.querySelector('#uc-create-btn').click();
+
+        expect(container.querySelector('#uc-question')).not.toBeNull();
+        expect(container.querySelectorAll('.uc-choice').length).toBe(4);
+        expect(container.querySelector('#uc-save-btn')).not.toBeNull();
+    });
+
+    test('クイズを作成して保存するとリストに表示される', () => {
+        initUserContent();
+        container.querySelector('#uc-create-btn').click();
+        fillCreateForm('1+1は？', ['1', '2', '3', '4'], 1);
+        container.querySelector('#uc-save-btn').click();
+
+        expect(container.querySelector('#uc-list').textContent).toContain('1+1は？');
+    });
+
+    test('問題未入力は保存されずメッセージ表示', () => {
+        initUserContent();
+        container.querySelector('#uc-create-btn').click();
+        fillCreateForm('', ['1', '2', '3', '4'], 1);
+        container.querySelector('#uc-save-btn').click();
+
+        expect(container.querySelector('#uc-message').textContent).toContain('もんだい');
+    });
+
+    test('正解未選択は保存されずメッセージ表示', () => {
+        initUserContent();
+        container.querySelector('#uc-create-btn').click();
+        fillCreateForm('問題', ['1', '2', '3', '4'], null);
+        container.querySelector('#uc-save-btn').click();
+
+        expect(container.querySelector('#uc-message').textContent).toContain('せいかい');
+    });
+
+    test('NGワード含む場合は保存を拒否', () => {
+        initUserContent();
+        container.querySelector('#uc-create-btn').click();
+        fillCreateForm('ばか', ['1', '2', '3', '4'], 1);
+        container.querySelector('#uc-save-btn').click();
+
+        expect(container.querySelector('#uc-message').textContent).toContain('つかえない');
+    });
+
+    test('作成クイズをプレイして正解', () => {
+        initUserContent();
+        container.querySelector('#uc-create-btn').click();
+        fillCreateForm('1+1は？', ['1', '2', '3', '4'], 1);
+        container.querySelector('#uc-save-btn').click();
+
+        // カードの「あそぶ」をクリック
+        const playBtn = Array.from(container.querySelectorAll('.uc-card .uc-button'))
+            .find(b => b.textContent === 'あそぶ');
+        playBtn.click();
+
+        // 正解(2=index1)をクリック
+        const correctBtn = Array.from(container.querySelectorAll('.uc-choice-btn'))
+            .find(b => b.textContent === '2');
+        correctBtn.click();
+
+        expect(container.querySelector('#uc-feedback').textContent).toContain('せいかい');
+        expect(correctBtn.classList.contains('correct')).toBe(true);
+    });
+
+    test('報告するとカードがreportedマーク付きで再描画', () => {
+        initUserContent();
+        container.querySelector('#uc-create-btn').click();
+        fillCreateForm('問題', ['a', 'b', 'c', 'd'], 0);
+        container.querySelector('#uc-save-btn').click();
+
+        const reportBtn = Array.from(container.querySelectorAll('.uc-card .uc-button'))
+            .find(b => b.textContent === 'ほうこく');
+        reportBtn.click();
+
+        expect(container.querySelector('.uc-card.reported')).not.toBeNull();
+    });
+
+    test('削除するとリストから消える', () => {
+        initUserContent();
+        container.querySelector('#uc-create-btn').click();
+        fillCreateForm('問題', ['a', 'b', 'c', 'd'], 0);
+        container.querySelector('#uc-save-btn').click();
+        expect(container.querySelectorAll('.uc-card').length).toBe(1);
+
+        const delBtn = Array.from(container.querySelectorAll('.uc-card .uc-button'))
+            .find(b => b.textContent === 'けす');
+        delBtn.click();
+
+        expect(container.querySelector('#uc-list').textContent).toContain('まだありません');
+    });
+});


### PR DESCRIPTION
ユーザー作成クイズ「クイズをつくろう」を all-ages.html に追加。

## 機能
- クイズ作成（問題文・選択肢4つ・正解選択）
- 作成クイズの一覧・プレイ・削除
- NGワード簡易フィルタ（不適切語の保存拒否）
- 報告マーク機能

## 設計上の制約
静的サイト（バックエンドなし）のため、保存は **localStorage（同ブラウザ内のみ）**。issueの「他ユーザーへの公開共有」は技術制約上不可。ローカルで作成→プレイの体験を提供。画像は絵文字で代替。

- user-content.js / user-content.test.js（新規、11テスト）
- all-ages.html（ナビ/セクション/script/リスナー）
- style.css（uc-* スタイル）、README.md

`npm test` → 33 files / 417 tests passed

Closes #16