### PR TITLE
feat(coding): 7-8歳にプログラミング基礎ゲームを追加 (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The website is structured by age group, and each page bundles several games that
     *   Kanji Puzzle (漢字パズル)
     *   Word Relay (ことばリレー)
     *   Instrument Play (がっきたいきごう) — play piano and drums
+    *   Coding Game (プログラミングあそび) — arrange blocks to move the character
 *   **9-10 years old (3rd-4th Grade):** Games that develop practical skills
     *   Fraction Pizza (分数ピザ)
     *   Multiplication Battle (九九バトル)
@@ -77,7 +78,7 @@ To preview the app, open `index.html` in a browser, or serve the directory with 
 
 ## Testing
 
-Every game and shared module has a companion `*.test.js` file (32 in total), run with Vitest in a jsdom environment:
+Every game and shared module has a companion `*.test.js` file (33 in total), run with Vitest in a jsdom environment:
 
 
 ```bash

--- a/ages-7-8.html
+++ b/ages-7-8.html
@@ -52,6 +52,13 @@
                     <span class="game-title">がっき</span>
                     <span class="game-description">ピアノやドラム</span>
                 </button>
+                <button id="coding-game-btn" class="game-nav-button"
+                        role="tab" aria-selected="false" aria-controls="coding-game-section"
+                        aria-label="プログラミングあそび - ブロックをならべてうごかそう">
+                    <span class="game-icon" aria-hidden="true">🧩</span>
+                    <span class="game-title">プログラミング</span>
+                    <span class="game-description">ブロックでうごかそう</span>
+                </button>
             </div>
         </div>
 
@@ -88,6 +95,12 @@
             <div id="instrument-sim"></div>
         </div>
 
+        <!-- プログラミングあそびセクション -->
+        <div id="coding-game-section" class="game-section"
+             role="tabpanel" aria-labelledby="coding-game-btn" aria-hidden="true">
+            <div id="coding-game"></div>
+        </div>
+
         <a href="index.html" class="back-link">トップにもどる</a>
     </main>
 
@@ -101,6 +114,7 @@
     <script src="kanji-puzzle.js"></script>
     <script src="word-relay.js"></script>
     <script src="instrument-sim.js"></script>
+    <script src="coding-game.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             var kanjiPuzzleInstance = null;
@@ -144,6 +158,9 @@
             });
             document.getElementById('instrument-sim-btn').addEventListener('click', function() {
                 switchToGame('instrument-sim');
+            });
+            document.getElementById('coding-game-btn').addEventListener('click', function() {
+                switchToGame('coding-game');
             });
 
             switchToGame('math-battle');

--- a/coding-game.js
+++ b/coding-game.js
@@ -1,0 +1,226 @@
+/**
+ * プログラミングあそび（プログラミング基礎ゲーム）
+ * Coding Game for ages 7-8
+ *
+ * ブロック（まえへ/みぎ/ひだり）をクリックでプログラムに並べ、実行すると
+ * キャラがグリッド上を動く。ゴールに届けばクリア、複数ステージ。
+ */
+
+function initCodingGame() {
+    var container = document.getElementById('coding-game');
+    if (!container) return;
+
+    var GRID = 5;
+    // direction: 0=up, 1=right, 2=down, 3=left
+    var DIR_VEC = { 0: [0, -1], 1: [1, 0], 2: [0, 1], 3: [-1, 0] };
+
+    var stages = [
+        { start: { x: 0, y: 4, dir: 1 }, goal: { x: 4, y: 4 } },
+        { start: { x: 0, y: 0, dir: 2 }, goal: { x: 0, y: 4 } },
+        { start: { x: 0, y: 0, dir: 1 }, goal: { x: 4, y: 4 } },
+    ];
+
+    var stageIdx = 0;
+    var player = { x: 0, y: 0, dir: 0 };
+    var program = [];
+    var running = false;
+    var timer = null;
+
+    function loadStage(i) {
+        var s = stages[i];
+        player = { x: s.start.x, y: s.start.y, dir: s.start.dir };
+        program = [];
+        running = false;
+        if (timer) { clearInterval(timer); timer = null; }
+        render();
+    }
+
+    function buildUI() {
+        container.textContent = '';
+
+        var header = document.createElement('div');
+        header.className = 'coding-header';
+        var title = document.createElement('h2');
+        title.textContent = 'プログラミングあそび';
+        header.appendChild(title);
+        var stageLabel = document.createElement('span');
+        stageLabel.className = 'coding-stage';
+        stageLabel.id = 'coding-stage';
+        header.appendChild(stageLabel);
+        container.appendChild(header);
+
+        var grid = document.createElement('div');
+        grid.className = 'coding-grid';
+        grid.id = 'coding-grid';
+        container.appendChild(grid);
+
+        var palette = document.createElement('div');
+        palette.className = 'coding-palette';
+        palette.id = 'coding-palette';
+        [['forward', 'まえへ 1マス'], ['right', 'みぎに まわる'], ['left', 'ひだりに まわる']].forEach(function (pair) {
+            var btn = document.createElement('button');
+            btn.className = 'coding-block-btn';
+            btn.textContent = pair[1];
+            btn.dataset.type = pair[0];
+            btn.addEventListener('click', function () { addBlock(pair[0]); });
+            palette.appendChild(btn);
+        });
+        container.appendChild(palette);
+
+        var progLabel = document.createElement('h3');
+        progLabel.textContent = 'プログラム（ならんだ じゅん）';
+        container.appendChild(progLabel);
+
+        var programEl = document.createElement('div');
+        programEl.className = 'coding-program';
+        programEl.id = 'coding-program';
+        container.appendChild(programEl);
+
+        var controls = document.createElement('div');
+        controls.className = 'coding-controls';
+
+        var runBtn = document.createElement('button');
+        runBtn.className = 'coding-run-btn';
+        runBtn.id = 'coding-run-btn';
+        runBtn.textContent = 'じっこう';
+        runBtn.addEventListener('click', run);
+        controls.appendChild(runBtn);
+
+        var clearBtn = document.createElement('button');
+        clearBtn.className = 'coding-clear-btn';
+        clearBtn.textContent = 'プログラムを けす';
+        clearBtn.addEventListener('click', function () { program = []; renderProgram(); });
+        controls.appendChild(clearBtn);
+
+        var resetBtn = document.createElement('button');
+        resetBtn.className = 'coding-reset-btn';
+        resetBtn.textContent = 'もういちど';
+        resetBtn.addEventListener('click', function () { loadStage(stageIdx); });
+        controls.appendChild(resetBtn);
+
+        container.appendChild(controls);
+
+        var msg = document.createElement('p');
+        msg.className = 'coding-message';
+        msg.id = 'coding-message';
+        container.appendChild(msg);
+
+        loadStage(stageIdx);
+    }
+
+    function addBlock(type) {
+        if (running) return;
+        program.push({ type: type });
+        renderProgram();
+    }
+
+    function blockLabel(type) {
+        return { forward: 'まえへ', right: 'みぎ', left: 'ひだり' }[type];
+    }
+
+    function renderProgram() {
+        var el = document.getElementById('coding-program');
+        el.textContent = '';
+        if (program.length === 0) {
+            el.textContent = 'ブロックを ついかしてね';
+            return;
+        }
+        program.forEach(function (b, i) {
+            var chip = document.createElement('span');
+            chip.className = 'coding-chip coding-chip-' + b.type;
+            chip.textContent = (i + 1) + '. ' + blockLabel(b.type);
+            el.appendChild(chip);
+        });
+    }
+
+    function render() {
+        var stage = stages[stageIdx];
+        var grid = document.getElementById('coding-grid');
+        grid.textContent = '';
+        for (var y = 0; y < GRID; y++) {
+            for (var x = 0; x < GRID; x++) {
+                var cell = document.createElement('div');
+                cell.className = 'coding-cell';
+                if (x === stage.goal.x && y === stage.goal.y) {
+                    cell.classList.add('goal');
+                    cell.textContent = '🎯';
+                }
+                if (x === player.x && y === player.y) {
+                    cell.classList.add('player');
+                    cell.textContent = '🐱';
+                }
+                grid.appendChild(cell);
+            }
+        }
+        document.getElementById('coding-stage').textContent = 'ステージ ' + (stageIdx + 1);
+        renderProgram();
+    }
+
+    function run() {
+        if (running) return;
+        if (program.length === 0) {
+            setMessage('ブロックを ならべてね', '');
+            return;
+        }
+        running = true;
+        setMessage('じっこうちゅう...', '');
+        var step = 0;
+        timer = setInterval(function () {
+            if (step >= program.length) {
+                clearInterval(timer);
+                timer = null;
+                running = false;
+                checkResult();
+                return;
+            }
+            execute(program[step].type);
+            step++;
+        }, 500);
+    }
+
+    function execute(type) {
+        if (type === 'forward') {
+            var vec = DIR_VEC[player.dir];
+            var nx = player.x + vec[0];
+            var ny = player.y + vec[1];
+            if (nx >= 0 && nx < GRID && ny >= 0 && ny < GRID) {
+                player.x = nx;
+                player.y = ny;
+            }
+        } else if (type === 'right') {
+            player.dir = (player.dir + 1) % 4;
+        } else if (type === 'left') {
+            player.dir = (player.dir + 3) % 4;
+        }
+        render();
+    }
+
+    function checkResult() {
+        var goal = stages[stageIdx].goal;
+        if (player.x === goal.x && player.y === goal.y) {
+            setMessage('クリア！やったー！ 🎉', 'success');
+            if (stageIdx < stages.length - 1) {
+                stageIdx++;
+                setTimeout(function () { loadStage(stageIdx); }, 1500);
+            }
+        } else {
+            setMessage('ゴールに つかなかったよ。もういっかい！', 'fail');
+        }
+    }
+
+    function setMessage(text, kind) {
+        var el = document.getElementById('coding-message');
+        el.textContent = text;
+        el.className = 'coding-message' + (kind ? ' ' + kind : '');
+    }
+
+    buildUI();
+}
+
+if (typeof window !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', initCodingGame);
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { initCodingGame };
+}

--- a/coding-game.test.js
+++ b/coding-game.test.js
@@ -1,0 +1,115 @@
+/**
+ * プログラミングあそび（プログラミング基礎ゲーム）のテスト
+ * Tests for CodingGame
+ */
+
+const { initCodingGame } = require('./coding-game.js');
+
+describe('initCodingGame', () => {
+    let container;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        container.id = 'coding-game';
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+        vi.useRealTimers();
+    });
+
+    function playerCellIndex() {
+        const cells = container.querySelectorAll('.coding-cell');
+        const playerCell = container.querySelector('.coding-cell.player');
+        return Array.from(cells).indexOf(playerCell);
+    }
+
+    test('コンテナが存在する場合、UIが作成される', () => {
+        initCodingGame();
+
+        expect(container.querySelector('.coding-grid')).not.toBeNull();
+        expect(container.querySelector('#coding-palette')).not.toBeNull();
+        expect(container.querySelector('#coding-program')).not.toBeNull();
+        expect(container.querySelector('#coding-run-btn')).not.toBeNull();
+    });
+
+    test('コンテナが存在しない場合はエラーにならない', () => {
+        expect(() => initCodingGame()).not.toThrow();
+    });
+
+    test('パレットに3つのブロックボタンが表示される', () => {
+        initCodingGame();
+
+        expect(container.querySelectorAll('.coding-block-btn').length).toBe(3);
+    });
+
+    test('初期はステージ1・キャラとゴールが表示される', () => {
+        initCodingGame();
+
+        expect(container.querySelector('#coding-stage').textContent).toContain('ステージ 1');
+        expect(container.querySelector('.coding-cell.player').textContent).toBe('🐱');
+        expect(container.querySelector('.coding-cell.goal').textContent).toBe('🎯');
+    });
+
+    test('ブロックを追加するとプログラムに並ぶ', () => {
+        initCodingGame();
+
+        container.querySelector('[data-type="forward"]').click();
+        container.querySelector('[data-type="right"]').click();
+
+        const chips = container.querySelectorAll('.coding-chip');
+        expect(chips.length).toBe(2);
+        expect(chips[0].textContent).toContain('まえへ');
+        expect(chips[1].textContent).toContain('みぎ');
+    });
+
+    test('「まえへ」を実行するとキャラが1マス進む', () => {
+        vi.useFakeTimers();
+        initCodingGame();
+
+        // ステージ1: start {x:0,y:4,dir:1(right)} → forward → x=1,y=4 → index=4*5+1=21
+        container.querySelector('[data-type="forward"]').click();
+        container.querySelector('#coding-run-btn').click();
+        vi.advanceTimersByTime(600);
+
+        expect(playerCellIndex()).toBe(21);
+    });
+
+    test('ステージ1をクリアするとステージ2へ進む', () => {
+        vi.useFakeTimers();
+        initCodingGame();
+
+        // ステージ1: start {0,4,dir:right}, goal {4,4}. 右へ4回進む
+        for (let i = 0; i < 4; i++) {
+            container.querySelector('[data-type="forward"]').click();
+        }
+        container.querySelector('#coding-run-btn').click();
+        vi.advanceTimersByTime(2500); // 4ステップ + 余裕
+
+        expect(container.querySelector('#coding-message').textContent).toContain('クリア');
+        // 1.5秒後に次ステージ
+        vi.advanceTimersByTime(2000);
+        expect(container.querySelector('#coding-stage').textContent).toContain('ステージ 2');
+    });
+
+    test('ゴールに届かないと失敗メッセージ', () => {
+        vi.useFakeTimers();
+        initCodingGame();
+
+        container.querySelector('[data-type="right"]').click(); // 向きだけ変える
+        container.querySelector('#coding-run-btn').click();
+        vi.advanceTimersByTime(1100);
+
+        expect(container.querySelector('#coding-message').textContent).toContain('つかなかった');
+    });
+
+    test('プログラム解除でブロックが消える', () => {
+        initCodingGame();
+        container.querySelector('[data-type="forward"]').click();
+        expect(container.querySelectorAll('.coding-chip').length).toBe(1);
+
+        container.querySelector('.coding-clear-btn').click();
+        expect(container.querySelectorAll('.coding-chip').length).toBe(0);
+    });
+});

--- a/style.css
+++ b/style.css
@@ -2969,6 +2969,142 @@ footer {
 }
 
 /* ========================================
+   プログラミングあそび（プログラミング基礎ゲーム）
+   ======================================== */
+.coding-header h2 {
+    margin: 0;
+    display: inline;
+}
+
+.coding-stage {
+    margin-left: 12px;
+    font-weight: bold;
+    color: #00695c;
+}
+
+.coding-grid {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 2px;
+    max-width: 300px;
+    margin: 16px auto;
+    background: #b2dfdb;
+    padding: 2px;
+    border-radius: 8px;
+}
+
+.coding-cell {
+    aspect-ratio: 1;
+    background: #e0f2f1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+}
+
+.coding-cell.goal {
+    background: #fff9c4;
+}
+
+.coding-cell.player {
+    background: #c8e6c9;
+}
+
+.coding-palette {
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+    flex-wrap: wrap;
+    margin: 12px 0;
+}
+
+.coding-block-btn {
+    font-size: 1rem;
+    padding: 8px 14px;
+    border: 2px solid #26a69a;
+    border-radius: 12px;
+    background: #fff;
+    color: #00695c;
+    cursor: pointer;
+}
+
+.coding-block-btn:hover {
+    background: #e0f2f1;
+}
+
+.coding-program {
+    min-height: 2em;
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 8px;
+    color: #777;
+}
+
+.coding-chip {
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: #b2dfdb;
+    color: #004d40;
+    font-size: 0.9rem;
+}
+
+.coding-chip-forward {
+    background: #c8e6c9;
+}
+
+.coding-chip-right {
+    background: #bbdefb;
+}
+
+.coding-chip-left {
+    background: #ffe0b2;
+}
+
+.coding-controls {
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+    margin: 12px 0;
+}
+
+.coding-run-btn {
+    font-size: 1.1rem;
+    font-weight: bold;
+    padding: 8px 20px;
+    border: none;
+    border-radius: 999px;
+    background: #26a69a;
+    color: #fff;
+    cursor: pointer;
+}
+
+.coding-clear-btn, .coding-reset-btn {
+    font-size: 0.9rem;
+    padding: 8px 14px;
+    border: 2px solid #80cbc4;
+    border-radius: 999px;
+    background: #fff;
+    color: #00695c;
+    cursor: pointer;
+}
+
+.coding-message {
+    font-weight: bold;
+    min-height: 1.5em;
+    margin-top: 8px;
+}
+
+.coding-message.success {
+    color: #2e7d32;
+}
+
+.coding-message.fail {
+    color: #c62828;
+}
+
+/* ========================================
    クイズをつくろう（ユーザー作成コンテンツ）
    ======================================== */
 .user-content-header h2 {


### PR DESCRIPTION
プログラミング基礎ゲーム「プログラミングあそび」を7-8歳ページに追加。

- coding-game.js / coding-game.test.js（新規、9テスト）
- ages-7-8.html（ナビ/セクション/script/リスナー）
- style.css（coding-* スタイル）、README.md

ブロック（まえへ/みぎ/ひだり）をクリックでプログラムに並べ、実行するとキャラ🐱が5×5グリッドを移動。ゴール🎯到達でクリア、3ステージ。setInterval で順次実行。

`npm test` → 34 files / passed

Closes #9