### PR TITLE
feat(astronomy): 9-10歳に天体観測シミュレーションを追加 (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ The website is structured by age group, and each page bundles several games that
     *   Fraction Pizza (分数ピザ)
     *   Multiplication Battle (九九バトル)
     *   Kanji Puzzle (漢字パズル)
+    *   Story Creator (ものがたりづくり) — branching stories with save
+    *   Astronomy (ほしぞら観察) — explore a rotating starry sky
 *   **11-12 years old (5th-6th Grade):** Activities that encourage inquiry-based learning
     *   Speed Calculation (速さ計算)
     *   Kanji Puzzle (漢字パズル)
@@ -78,7 +80,7 @@ To preview the app, open `index.html` in a browser, or serve the directory with 
 
 ## Testing
 
-Every game and shared module has a companion `*.test.js` file (33 in total), run with Vitest in a jsdom environment:
+Every game and shared module has a companion `*.test.js` file (34 in total), run with Vitest in a jsdom environment:
 
 
 ```bash

--- a/ages-9-10.html
+++ b/ages-9-10.html
@@ -45,6 +45,13 @@
                     <span class="game-title">ものがたり</span>
                     <span class="game-description">えらんで つくろう</span>
                 </button>
+                <button id="astronomy-sim-btn" class="game-nav-button"
+                        role="tab" aria-selected="false" aria-controls="astronomy-sim-section"
+                        aria-label="ほしぞら観察 - ほしや星座をみよう">
+                    <span class="game-icon" aria-hidden="true">🌟</span>
+                    <span class="game-title">ほしぞら</span>
+                    <span class="game-description">ほしをみよう</span>
+                </button>
             </div>
         </div>
 
@@ -75,6 +82,12 @@
             <div id="story-creator"></div>
         </div>
 
+        <!-- ほしぞら観察セクション -->
+        <div id="astronomy-sim-section" class="game-section"
+             role="tabpanel" aria-labelledby="astronomy-sim-btn" aria-hidden="true">
+            <div id="astronomy-sim"></div>
+        </div>
+
         <a href="index.html" class="back-link">トップにもどる</a>
     </main>
 
@@ -87,6 +100,7 @@
     <script src="kanji-data.js"></script>
     <script src="kanji-puzzle.js"></script>
     <script src="story-creator.js"></script>
+    <script src="astronomy-sim.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function() {
             var kanjiPuzzleInstance = null;
@@ -127,6 +141,9 @@
             });
             document.getElementById('story-creator-btn').addEventListener('click', function() {
                 switchToGame('story-creator');
+            });
+            document.getElementById('astronomy-sim-btn').addEventListener('click', function() {
+                switchToGame('astronomy-sim');
             });
 
             switchToGame('fraction');

--- a/astronomy-sim.js
+++ b/astronomy-sim.js
@@ -1,0 +1,201 @@
+/**
+ * ほしぞら観察（天体観測シミュレーション）
+ * Astronomy Simulation for ages 9-10
+ *
+ * Canvas に簡易星空を描画。時間スライダーで星空が回転し、
+ * 星座をクリックすると名前と説明を表示。本格的な天体計算は行わない。
+ * 回転計算は純粋関数（getSkyRotation / rotatePoint）として分離しテスト可能。
+ */
+
+function getSkyRotation(hour) {
+    // 0-24時 → 0-360度（1日で1回転）
+    return (hour / 24) * 360;
+}
+
+function rotatePoint(x, y, deg) {
+    var rad = deg * Math.PI / 180;
+    return {
+        x: x * Math.cos(rad) - y * Math.sin(rad),
+        y: x * Math.sin(rad) + y * Math.cos(rad)
+    };
+}
+
+var CONSTELLATIONS = [
+    {
+        name: 'オリオンざ',
+        stars: [{ x: -0.35, y: -0.1 }, { x: -0.15, y: 0.05 }, { x: 0.05, y: -0.05 }, { x: 0.25, y: 0.1 }],
+        lines: [[0, 1], [1, 2], [2, 3]],
+        info: '冬のゆうがたに みえる、ゆうめいな星座だよ！'
+    },
+    {
+        name: 'おおぐまざ',
+        stars: [{ x: 0.3, y: -0.35 }, { x: 0.45, y: -0.2 }, { x: 0.5, y: 0 }, { x: 0.4, y: 0.15 }],
+        lines: [[0, 1], [1, 2], [2, 3]],
+        info: '北斗七星を ふくむ、おおきな くまの 星座だよ！'
+    },
+    {
+        name: 'カシオペアざ',
+        stars: [{ x: -0.4, y: 0.3 }, { x: -0.25, y: 0.2 }, { x: -0.1, y: 0.35 }, { x: 0.05, y: 0.2 }],
+        lines: [[0, 1], [1, 2], [2, 3]],
+        info: 'Wのかたちをした 星座だよ！'
+    }
+];
+
+function initAstronomySim() {
+    var container = document.getElementById('astronomy-sim');
+    if (!container) return;
+
+    var hour = 21;
+    var zoom = 1;
+
+    function buildUI() {
+        container.textContent = '';
+
+        var header = document.createElement('div');
+        header.className = 'astro-header';
+        var title = document.createElement('h2');
+        title.textContent = 'ほしぞら観察';
+        header.appendChild(title);
+        container.appendChild(header);
+
+        var canvasWrap = document.createElement('div');
+        canvasWrap.className = 'astro-canvas-wrap';
+        var canvas = document.createElement('canvas');
+        canvas.id = 'astro-canvas';
+        canvas.className = 'astro-canvas';
+        canvas.width = 300;
+        canvas.height = 300;
+        canvasWrap.appendChild(canvas);
+        container.appendChild(canvasWrap);
+
+        var controls = document.createElement('div');
+        controls.className = 'astro-controls';
+
+        var sliderLabel = document.createElement('label');
+        sliderLabel.className = 'astro-field';
+        sliderLabel.textContent = 'じかん：';
+        var slider = document.createElement('input');
+        slider.type = 'range';
+        slider.min = '0';
+        slider.max = '24';
+        slider.value = String(hour);
+        slider.id = 'astro-hour';
+        slider.className = 'astro-slider';
+        sliderLabel.appendChild(slider);
+        controls.appendChild(sliderLabel);
+
+        var hourLabel = document.createElement('span');
+        hourLabel.id = 'astro-hour-label';
+        hourLabel.textContent = hour + '時';
+        controls.appendChild(hourLabel);
+
+        var zoomIn = document.createElement('button');
+        zoomIn.className = 'astro-zoom-btn';
+        zoomIn.id = 'astro-zoom-in';
+        zoomIn.textContent = '＋ おおきく';
+        zoomIn.addEventListener('click', function () { zoom = Math.min(2, zoom + 0.2); render(); });
+        controls.appendChild(zoomIn);
+
+        var zoomOut = document.createElement('button');
+        zoomOut.className = 'astro-zoom-btn';
+        zoomOut.id = 'astro-zoom-out';
+        zoomOut.textContent = '－ ちいさく';
+        zoomOut.addEventListener('click', function () { zoom = Math.max(0.5, zoom - 0.2); render(); });
+        controls.appendChild(zoomOut);
+
+        container.appendChild(controls);
+
+        var info = document.createElement('div');
+        info.className = 'astro-info';
+        info.id = 'astro-info';
+        info.textContent = 'ほしや星座を クリックしてみよう！';
+        container.appendChild(info);
+
+        slider.addEventListener('input', function () {
+            hour = parseInt(slider.value, 10);
+            hourLabel.textContent = hour + '時';
+            render();
+        });
+
+        canvas.addEventListener('click', function (e) { handleCanvasClick(e, canvas); });
+
+        render();
+    }
+
+    function render() {
+        var canvas = document.getElementById('astro-canvas');
+        if (!canvas) return;
+        var ctx = canvas.getContext('2d');
+        if (!ctx) return; // テスト環境（jsdom）など未対応なら何もしない
+
+        var w = canvas.width, h = canvas.height;
+        var cx = w / 2, cy = h / 2;
+        var rot = getSkyRotation(hour);
+
+        ctx.fillStyle = '#1a237e';
+        ctx.fillRect(0, 0, w, h);
+
+        CONSTELLATIONS.forEach(function (c) {
+            var pts = c.stars.map(function (s) {
+                var r = rotatePoint(s.x, s.y, rot);
+                return { x: cx + r.x * 150 * zoom, y: cy + r.y * 150 * zoom };
+            });
+            ctx.strokeStyle = '#90caf9';
+            ctx.lineWidth = 1;
+            ctx.beginPath();
+            c.lines.forEach(function (l) {
+                ctx.moveTo(pts[l[0]].x, pts[l[0]].y);
+                ctx.lineTo(pts[l[1]].x, pts[l[1]].y);
+            });
+            ctx.stroke();
+
+            ctx.fillStyle = '#fff59d';
+            pts.forEach(function (p) {
+                ctx.beginPath();
+                ctx.arc(p.x, p.y, 3, 0, Math.PI * 2);
+                ctx.fill();
+            });
+        });
+    }
+
+    function handleCanvasClick(e, canvas) {
+        var rect = canvas.getBoundingClientRect();
+        var mx = e.clientX - rect.left;
+        var my = e.clientY - rect.top;
+        var cx = canvas.width / 2, cy = canvas.height / 2;
+        var rot = getSkyRotation(hour);
+
+        var found = null;
+        var minDist = 999;
+        CONSTELLATIONS.forEach(function (c) {
+            c.stars.forEach(function (s) {
+                var r = rotatePoint(s.x, s.y, rot);
+                var px = cx + r.x * 150 * zoom;
+                var py = cy + r.y * 150 * zoom;
+                var d = Math.sqrt((px - mx) * (px - mx) + (py - my) * (py - my));
+                if (d < 20 && d < minDist) {
+                    minDist = d;
+                    found = c;
+                }
+            });
+        });
+
+        var info = document.getElementById('astro-info');
+        if (!info) return;
+        if (found) {
+            info.textContent = '✨ ' + found.name + ' ✨ ' + found.info;
+        } else {
+            info.textContent = 'ここには みあたらないよ。ほかのほしを ためしてみてね！';
+        }
+    }
+
+    buildUI();
+}
+
+if (typeof window !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', initAstronomySim);
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { initAstronomySim, getSkyRotation, rotatePoint };
+}

--- a/astronomy-sim.test.js
+++ b/astronomy-sim.test.js
@@ -1,0 +1,94 @@
+/**
+ * ほしぞら観察（天体観測シミュレーション）のテスト
+ * Tests for AstronomySim
+ */
+
+const { initAstronomySim, getSkyRotation, rotatePoint } = require('./astronomy-sim.js');
+
+describe('getSkyRotation', () => {
+    test('0時は0度', () => {
+        expect(getSkyRotation(0)).toBe(0);
+    });
+
+    test('12時は180度', () => {
+        expect(getSkyRotation(12)).toBe(180);
+    });
+
+    test('24時は360度', () => {
+        expect(getSkyRotation(24)).toBe(360);
+    });
+
+    test('6時は90度', () => {
+        expect(getSkyRotation(6)).toBe(90);
+    });
+});
+
+describe('rotatePoint', () => {
+    test('0度では同じ位置', () => {
+        const p = rotatePoint(1, 0, 0);
+        expect(p.x).toBeCloseTo(1);
+        expect(p.y).toBeCloseTo(0);
+    });
+
+    test('90度で回転する', () => {
+        const p = rotatePoint(1, 0, 90);
+        expect(p.x).toBeCloseTo(0);
+        expect(p.y).toBeCloseTo(1);
+    });
+
+    test('180度で反転する', () => {
+        const p = rotatePoint(1, 0, 180);
+        expect(p.x).toBeCloseTo(-1);
+        expect(p.y).toBeCloseTo(0);
+    });
+});
+
+describe('initAstronomySim', () => {
+    let container;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        container.id = 'astronomy-sim';
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        document.body.removeChild(container);
+    });
+
+    test('コンテナが存在する場合、UIが作成される', () => {
+        initAstronomySim();
+
+        expect(container.querySelector('#astro-canvas')).not.toBeNull();
+        expect(container.querySelector('#astro-hour')).not.toBeNull();
+        expect(container.querySelector('#astro-zoom-in')).not.toBeNull();
+        expect(container.querySelector('#astro-zoom-out')).not.toBeNull();
+        expect(container.querySelector('#astro-info')).not.toBeNull();
+    });
+
+    test('コンテナが存在しない場合はエラーにならない', () => {
+        expect(() => initAstronomySim()).not.toThrow();
+    });
+
+    test('初期時刻は夜の21時', () => {
+        initAstronomySim();
+
+        expect(container.querySelector('#astro-hour-label').textContent).toContain('21');
+    });
+
+    test('スライダー変更で時刻ラベルが更新される', () => {
+        initAstronomySim();
+
+        const slider = container.querySelector('#astro-hour');
+        slider.value = '5';
+        slider.dispatchEvent(new Event('input', { bubbles: true }));
+
+        expect(container.querySelector('#astro-hour-label').textContent).toContain('5');
+    });
+
+    test('初期の案内メッセージが表示される', () => {
+        initAstronomySim();
+
+        expect(container.querySelector('#astro-info').textContent).toContain('クリック');
+    });
+});

--- a/style.css
+++ b/style.css
@@ -2969,6 +2969,65 @@ footer {
 }
 
 /* ========================================
+   ほしぞら観察（天体観測シミュレーション）
+   ======================================== */
+.astro-header h2 {
+    margin: 0;
+}
+
+.astro-canvas-wrap {
+    display: flex;
+    justify-content: center;
+    margin: 16px 0;
+}
+
+.astro-canvas {
+    background: #1a237e;
+    border-radius: 12px;
+    max-width: 100%;
+    touch-action: none;
+}
+
+.astro-controls {
+    display: flex;
+    gap: 8px;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    margin: 12px 0;
+}
+
+.astro-field {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.astro-slider {
+    width: 150px;
+}
+
+.astro-zoom-btn {
+    font-size: 0.9rem;
+    padding: 6px 12px;
+    border: 2px solid #5c6bc0;
+    border-radius: 999px;
+    background: #fff;
+    color: #1a237e;
+    cursor: pointer;
+}
+
+.astro-info {
+    max-width: 500px;
+    margin: 12px auto;
+    padding: 12px;
+    background: #e8eaf6;
+    border-radius: 10px;
+    color: #1a237e;
+    min-height: 2em;
+}
+
+/* ========================================
    プログラミングあそび（プログラミング基礎ゲーム）
    ======================================== */
 .coding-header h2 {


### PR DESCRIPTION
天体観測シミュレーション「ほしぞら観察」を9-10歳ページに追加。

- astronomy-sim.js / astronomy-sim.test.js（新規、12テスト）
- ages-9-10.html（ナビ/セクション/script/リスナー）
- style.css（astro-* スタイル）、README.md（9-10歳にStory Creatorの欠落も補完）

Canvasで簡易星空を描画。時間スライダーで星空が回転（純粋関数 getSkyRotation/rotatePoint で計算、本格天体計算は擬似）、星座クリックで情報、ズームボタン。

`npm test` → 35 files / passed

Closes #10